### PR TITLE
fix: url includes bytes in python 3

### DIFF
--- a/git_os_job/cmd.py
+++ b/git_os_job/cmd.py
@@ -60,7 +60,8 @@ def main():
             sys.stderr.write('Could not get hash for ref %r\n' % ref)
             return 1
 
-    url = '%s/%s/%s/' % (args.base, ref_hash[:2], ref_hash)
+    ref_hash_str = ref_hash.decode('utf8')
+    url = '%s/%s/%s/' % (args.base, ref_hash_str[:2], ref_hash_str)
     if args.url:
         print(url)
     else:


### PR DESCRIPTION
This patch decodes the ref_hash obtained from subprocess.check_output
so that strings are used to compose the URL rather than bytes.
